### PR TITLE
refactor: with clang-tidy linter (resolves #9)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,168 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,304 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*,diagnostic-*,analyzer-*,readability-*,performance-*,clang-analyzer-*,bugprone-*,cppcoreguidelines-*,google-*,llvm-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            jo-bru
+CheckOptions:
+  - key:             bugprone-argument-comment.CommentBoolLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentCharacterLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentFloatLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentIntegerLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentNullPtrs
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentStringLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentUserDefinedLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.IgnoreSingleArgument
+    value:           '0'
+  - key:             bugprone-argument-comment.StrictMode
+    value:           '0'
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           assert
+  - key:             bugprone-assert-side-effect.CheckFunctionCalls
+    value:           '0'
+  - key:             bugprone-dangling-handle.HandleClasses
+    value:           'std::basic_string_view;std::experimental::basic_string_view'
+  - key:             bugprone-dynamic-static-initializers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             bugprone-exception-escape.FunctionsThatShouldNotThrow
+    value:           ''
+  - key:             bugprone-exception-escape.IgnoredExceptions
+    value:           ''
+  - key:             bugprone-misplaced-widening-cast.CheckImplicitCasts
+    value:           '0'
+  - key:             bugprone-not-null-terminated-result.WantToUseSafeFunctions
+    value:           '1'
+  - key:             bugprone-signed-char-misuse.CharTypdefsToIgnore
+    value:           ''
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant
+    value:           '1'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfConstant
+    value:           '1'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression
+    value:           '0'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfThis
+    value:           '1'
+  - key:             bugprone-string-constructor.LargeLengthThreshold
+    value:           '8388608'
+  - key:             bugprone-string-constructor.WarnOnLargeLength
+    value:           '1'
+  - key:             bugprone-suspicious-enum-usage.StrictMode
+    value:           '0'
+  - key:             bugprone-suspicious-missing-comma.MaxConcatenatedTokens
+    value:           '5'
+  - key:             bugprone-suspicious-missing-comma.RatioThreshold
+    value:           '0.200000'
+  - key:             bugprone-suspicious-missing-comma.SizeThreshold
+    value:           '5'
+  - key:             bugprone-suspicious-string-compare.StringCompareLikeFunctions
+    value:           ''
+  - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison
+    value:           '1'
+  - key:             bugprone-suspicious-string-compare.WarnOnLogicalNotComparison
+    value:           '0'
+  - key:             bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit
+    value:           '16'
+  - key:             bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
+    value:           '1'
+  - key:             bugprone-unused-return-value.CheckedFunctions
+    value:           '::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredFloatingPointValues
+    value:           '1.0;100.0;'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredIntegerValues
+    value:           '1;2;3;4;'
+  - key:             cppcoreguidelines-explicit-virtual-functions.AllowOverrideAndFinal
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.FinalSpelling
+    value:           final
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-explicit-virtual-functions.OverrideSpelling
+    value:           override
+  - key:             cppcoreguidelines-macro-usage.AllowedRegexp
+    value:           '^DEBUG_*'
+  - key:             cppcoreguidelines-macro-usage.CheckCapsOnly
+    value:           '0'
+  - key:             cppcoreguidelines-macro-usage.IgnoreCommandLineMacros
+    value:           '1'
+  - key:             cppcoreguidelines-no-malloc.Allocations
+    value:           '::malloc;::calloc'
+  - key:             cppcoreguidelines-no-malloc.Deallocations
+    value:           '::free'
+  - key:             cppcoreguidelines-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceConsumers
+    value:           '::free;::realloc;::freopen;::fclose'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceProducers
+    value:           '::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile'
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
+    value:           ''
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle
+    value:           '0'
+  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
+    value:           '0'
+  - key:             cppcoreguidelines-pro-type-member-init.UseAssignment
+    value:           '0'
+  - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions
+    value:           '0'
+  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value:           '0'
+  - key:             google-build-namespaces.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             google-global-names-in-headers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             google-runtime-int.SignedTypePrefix
+    value:           int
+  - key:             google-runtime-int.TypeSuffix
+    value:           ''
+  - key:             google-runtime-int.UnsignedTypePrefix
+    value:           uint
+  - key:             google-runtime-references.WhiteListTypes
+    value:           ''
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '1'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '1'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-make-shared.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-shared.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-shared.MakeSmartPtrFunction
+    value:           'std::make_shared'
+  - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-make-unique.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-unique.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'std::make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-pass-by-value.ValuesOnly
+    value:           '0'
+  - key:             modernize-raw-string-literal.ReplaceShorterLiterals
+    value:           '0'
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-random-shuffle.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-auto.MinTypeNameLength
+    value:           '5'
+  - key:             modernize-use-auto.RemoveStars
+    value:           '0'
+  - key:             modernize-use-default-member-init.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           '0'
+  - key:             modernize-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             modernize-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             modernize-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             modernize-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             modernize-use-equals-default.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-equals-delete.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-nodiscard.ReplacementString
+    value:           '[[nodiscard]]'
+  - key:             modernize-use-noexcept.ReplacementString
+    value:           ''
+  - key:             modernize-use-noexcept.UseNoexceptFalse
+    value:           '1'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-use-override.AllowOverrideAndFinal
+    value:           '0'
+  - key:             modernize-use-override.FinalSpelling
+    value:           final
+  - key:             modernize-use-override.IgnoreDestructors
+    value:           '0'
+  - key:             modernize-use-override.OverrideSpelling
+    value:           override
+  - key:             modernize-use-transparent-functors.SafeMode
+    value:           '0'
+  - key:             modernize-use-using.IgnoreMacros
+    value:           '1'
+  - key:             performance-faster-string-find.StringLikeClasses
+    value:           'std::basic_string'
+  - key:             performance-for-range-copy.AllowedTypes
+    value:           ''
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           '0'
+  - key:             performance-inefficient-string-concatenation.StrictMode
+    value:           '0'
+  - key:             performance-inefficient-vector-operation.EnableProto
+    value:           '0'
+  - key:             performance-inefficient-vector-operation.VectorLikeClasses
+    value:           '::std::vector'
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             performance-move-constructor-init.IncludeStyle
+    value:           llvm
+  - key:             performance-no-automatic-move.AllowedTypes
+    value:           ''
+  - key:             performance-type-promotion-in-math-fn.IncludeStyle
+    value:           llvm
+  - key:             performance-unnecessary-copy-initialization.AllowedTypes
+    value:           ''
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           ''
+  - key:             performance-unnecessary-value-param.IncludeStyle
+    value:           llvm
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             readability-else-after-return.WarnOnUnfixable
+    value:           '1'
+  - key:             readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             readability-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             readability-identifier-naming.IgnoreFailedSplit
+    value:           '0'
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           '0'
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           '0'
+  - key:             readability-inconsistent-declaration-parameter-name.IgnoreMacros
+    value:           '1'
+  - key:             readability-inconsistent-declaration-parameter-name.Strict
+    value:           '0'
+  - key:             readability-magic-numbers.IgnoredFloatingPointValues
+    value:           '1.0;100.0;'
+  - key:             readability-magic-numbers.IgnoredIntegerValues
+    value:           '1;2;3;4;'
+  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value:           '0'
+  - key:             readability-redundant-smartptr-get.IgnoreMacros
+    value:           '1'
+  - key:             readability-redundant-string-init.StringNames
+    value:           '::std::basic_string'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value:           '0'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
+    value:           '0'
+  - key:             readability-simplify-subscript-expr.Types
+    value:           '::std::basic_string;::std::basic_string_view;::std::vector;::std::array'
+  - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
+    value:           '3'
+  - key:             readability-uppercase-literal-suffix.IgnoreMacros
+    value:           '1'
+  - key:             readability-uppercase-literal-suffix.NewSuffixes
+    value:           ''
+...
+

--- a/README.md
+++ b/README.md
@@ -42,24 +42,18 @@ xarm-commander -h
 ```
 > :bulb: Can be also used for subcommands: `xarm-commander get_version -h`  
 
-## Configuration Parameters
-### Formatter:
-Formatting engine: `clangFormat`  
-Formatting style: `Visual Studio`
+## Formatting
+The formatting style used in this project is Google with an indent of 4 (see `.clang-format`).  
+To format the source code, run the following:
+```
+clang-format -i -style=file src/xarm-commander.cpp
+```
 
-### Linter:
-Linter: `clang-tidy` (LLVM version 10.0.0)  
-Linter checks: 
-
-        "modernize-*",
-        "diagnostic-*",
-        "analyzer-*",
-        "readability-*",
-        "performance-*",
-        "clang-analyzer-*",
-        "bugprone-*",
-        "cppcoreguidelines-*",
-        "google-*",
-        "llvm-*"
+## Linting
+Currently, clang-tidy is used for linting (see `.clang-tidy`).  
+To lint the source code, run the following:
+```
+clang-tidy src/xarm-commander.cpp -- -Iinclude
+```
         
 > :exclamation: Checks partially overlap (TODO)

--- a/README.md
+++ b/README.md
@@ -42,3 +42,24 @@ xarm-commander -h
 ```
 > :bulb: Can be also used for subcommands: `xarm-commander get_version -h`  
 
+## Configuration Parameters
+### Formatter:
+Formatting engine: `clangFormat`  
+Formatting style: `Visual Studio`
+
+### Linter:
+Linter: `clang-tidy` (LLVM version 10.0.0)  
+Linter checks: 
+
+        "modernize-*",
+        "diagnostic-*",
+        "analyzer-*",
+        "readability-*",
+        "performance-*",
+        "clang-analyzer-*",
+        "bugprone-*",
+        "cppcoreguidelines-*",
+        "google-*",
+        "llvm-*"
+        
+> :exclamation: Checks partially overlap (TODO)

--- a/src/xarm-commander.cpp
+++ b/src/xarm-commander.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
 
     // ===== OPTIONS =====
     std::string port; // 130.82.171.9
-    app.add_option("-p, --port", port, "ip-address of xArm control box");
+    app.add_option("-p, --port", port, "ip-address of xArm control box")->required();
 
     // ===== SUBCOMMANDS =====
     app.require_subcommand(1); // set max number of subcommands to 1

--- a/src/xarm-commander.cpp
+++ b/src/xarm-commander.cpp
@@ -1,14 +1,22 @@
 #include <CLI11.hpp>
 #include <xarm/wrapper/xarm_api.h>
 
-#include <string>
 #include <iostream>
+#include <string>
 
 int main(int argc, char **argv)
 {
+    // Default values (to avoid magic numbers) => not sure if this is the way to go (maybe using namespace, seperate headerfile?)
+    constexpr float kDefaultPosX = 300;
+    constexpr float kDefaultPosY = 0;
+    constexpr float kDefaultPosZ = 200;
+    constexpr float kDefaultPosRoll = 180; // [Deg] by default
+    constexpr float kDefaultPosPitch = 0;  // [Deg] by default
+    constexpr float kDefaultPosYaw = 0;    // [Deg] by default
 
-    XArmAPI *arm;
-    int res = 1;
+    constexpr int kAllServo = 8;
+
+    int res{1};
 
     CLI::App app{"xarm-commander: a command line tool for controlling the xArm7."};
 
@@ -17,7 +25,7 @@ int main(int argc, char **argv)
 
     // ===== FLAGS =====
     bool print_mode{false};
-    app.add_flag("-v, --verbose", print_mode, "verbose mode."); // TODO: multilevel verbose modes + logger
+    app.add_flag("-v, --verbose", print_mode, "verbose mode."); // TODO(jo-bru): multilevel verbose modes + logger
 
     // ===== OPTIONS =====
     std::string port; // 130.82.171.9
@@ -32,11 +40,11 @@ int main(int argc, char **argv)
     bool enable_flag{true};
     motion_enable->add_flag("-e, --enable, -d{false}, --disable{false}", enable_flag, "enable or disable the xArm (default: --enable)");
 
-    int servo_option{8};
+    int servo_option{kAllServo};
     motion_enable->add_option("-s, --servo", servo_option, "choose servo [1-8] to be enabled/disabled, (default: 8 - enable/disable all servo)");
 
     motion_enable->callback([&]() {
-        arm = new XArmAPI(port);
+        auto *arm = new XArmAPI(port);
         res = arm->motion_enable(enable_flag, servo_option);
 
         if (print_mode)
@@ -46,13 +54,13 @@ int main(int argc, char **argv)
     });
 
     // Subcommand: set_state
-    auto set_state = app.add_subcommand("set_state", "send a set_state command");
+    auto *set_state = app.add_subcommand("set_state", "send a set_state command");
 
     int state_option{0};
     set_state->add_option("-s, --state", state_option, "state, 0: sport, 3: pause, 4: stop");
 
     set_state->callback([&]() {
-        arm = new XArmAPI(port);
+        auto *arm = new XArmAPI(port);
         res = arm->set_state(state_option);
 
         if (print_mode)
@@ -62,13 +70,13 @@ int main(int argc, char **argv)
     });
 
     // Subcommand: set_mode
-    auto set_mode = app.add_subcommand("set_mode", "send a set_mode command");
+    auto *set_mode = app.add_subcommand("set_mode", "send a set_mode command");
 
     int mode_option = 0;
     set_mode->add_option("-m", mode_option, "mode, 0: position control mode, 1: servo motion mode, 2: joint teaching mode, 3: cartesian teaching mode (invalid), 4: simulation mode");
 
     set_mode->callback([&]() {
-        arm = new XArmAPI(port);
+        auto *arm = new XArmAPI(port);
         res = arm->set_mode(mode_option);
 
         if (print_mode)
@@ -78,10 +86,10 @@ int main(int argc, char **argv)
     });
 
     // Subcommand: get_version
-    auto get_version = app.add_subcommand("get_version", "send a get_version command");
+    auto *get_version = app.add_subcommand("get_version", "send a get_version command");
     get_version->callback([&]() {
-        arm = new XArmAPI(port);
-        res = arm->get_version(arm->version); // TODO: check if this is even needed or arm->version holds an updated version
+        auto *arm = new XArmAPI(port);
+        res = arm->get_version(arm->version); // TODO(jo-bru): check if this is even needed or arm->version holds an updated version
 
         if (print_mode)
         {
@@ -92,9 +100,9 @@ int main(int argc, char **argv)
     });
 
     // Subcommand: get_state
-    auto get_state = app.add_subcommand("get_state", "send a get_state commmand");
+    auto *get_state = app.add_subcommand("get_state", "send a get_state commmand");
     get_state->callback([&]() {
-        arm = new XArmAPI(port);
+        auto *arm = new XArmAPI(port);
         res = arm->get_state(&arm->state);
 
         if (print_mode)
@@ -106,9 +114,9 @@ int main(int argc, char **argv)
     });
 
     // Subcommand: get_position
-    auto get_position = app.add_subcommand("get_position", "send a get_position command to get the cartesian position");
+    auto *get_position = app.add_subcommand("get_position", "send a get_position command to get the cartesian position");
     get_position->callback([&]() {
-        arm = new XArmAPI(port);
+        auto *arm = new XArmAPI(port);
         res = arm->get_position(arm->position);
 
         if (print_mode)
@@ -125,26 +133,26 @@ int main(int argc, char **argv)
     });
 
     // Subcommand: set_position
-    auto set_position = app.add_subcommand("set_position", "send a set_position command to get the cartesian position");
+    auto *set_position = app.add_subcommand("set_position", "send a set_position command to get the cartesian position");
 
-    float x_option = 300;
+    float x_option = kDefaultPosX;
     set_position->add_option("-x", x_option, "x(mm)");
-    float y_option = 0;
+    float y_option = kDefaultPosYaw;
     set_position->add_option("-y", y_option, "y(mm)");
-    float z_option = 200;
+    float z_option = kDefaultPosZ;
     set_position->add_option("-z", z_option, "z(mm)");
-    float roll_option = 180;
+    float roll_option = kDefaultPosRoll;
     set_position->add_option("-r, --roll", roll_option, "roll(rad or °)");
-    float pitch_option = 0;
+    float pitch_option = kDefaultPosPitch;
     set_position->add_option("-p, --pitch", pitch_option, "pitch(rad or °)");
-    float yaw_option = 0;
+    float yaw_option = kDefaultPosYaw;
     set_position->add_option("-w, --yaw", yaw_option, "yaw(rad or °)");
 
     bool wait_option = false;
     set_position->add_option("--wait", wait_option, "whether to wait for the arm to complete");
 
     set_position->callback([&]() {
-        arm = new XArmAPI(port);
+        auto *arm = new XArmAPI(port);
 
         float pose[6];
         pose[0] = x_option;
@@ -161,8 +169,11 @@ int main(int argc, char **argv)
             std::cout << "Set position - Response: " << res << "\n"
                       << "Position: ";
             std::cout << "[ ";
-            for (int i = 0; i < 6; i++)
-                std::cout << pose[i] << " ";
+            // range-based for loop
+            for (float position : pose)
+            {
+                std::cout << position << " ";
+            }
             std::cout << "]"
                       << "\n";
         }

--- a/src/xarm-commander.cpp
+++ b/src/xarm-commander.cpp
@@ -1,71 +1,82 @@
-#include <CLI11.hpp>
 #include <xarm/wrapper/xarm_api.h>
 
+#include <CLI11.hpp>
 #include <iostream>
 #include <string>
 
-int main(int argc, char **argv)
-{
-    // Default values (to avoid magic numbers) => not sure if this is the way to go (maybe using namespace, seperate headerfile?)
+int main(int argc, char **argv) {
+    // Default values (to avoid magic numbers) => not sure if this is the
+    // way to go (maybe using namespace, seperate headerfile?)
     constexpr float kDefaultPosX = 300;
     constexpr float kDefaultPosY = 0;
     constexpr float kDefaultPosZ = 200;
-    constexpr float kDefaultPosRoll = 180; // [Deg] by default
-    constexpr float kDefaultPosPitch = 0;  // [Deg] by default
-    constexpr float kDefaultPosYaw = 0;    // [Deg] by default
+    constexpr float kDefaultPosRoll = 180;  // [Deg] by default
+    constexpr float kDefaultPosPitch = 0;   // [Deg] by default
+    constexpr float kDefaultPosYaw = 0;     // [Deg] by default
 
     constexpr int kAllServo = 8;
 
     int res{1};
 
-    CLI::App app{"xarm-commander: a command line tool for controlling the xArm7."};
+    CLI::App app{
+        "xarm-commander: a command line tool for controlling the xArm7."};
 
     // print defaults on help
     app.option_defaults()->always_capture_default();
 
     // ===== FLAGS =====
     bool print_mode{false};
-    app.add_flag("-v, --verbose", print_mode, "verbose mode."); // TODO(jo-bru): multilevel verbose modes + logger
+    app.add_flag("-v, --verbose", print_mode,
+                 "verbose mode.");  // TODO(jo-bru): multilevel verbose
+                                    // modes + logger
 
     // ===== OPTIONS =====
-    std::string port; // 130.82.171.9
-    app.add_option("-p, --port", port, "ip-address of xArm control box")->required();
+    std::string port;  // 130.82.171.9
+    app.add_option("-p, --port", port, "ip-address of xArm control box")
+        ->required();
 
     // ===== SUBCOMMANDS =====
-    app.require_subcommand(1); // set max number of subcommands to 1
+    app.require_subcommand(1);  // set max number of subcommands to 1
 
     // Subcommand: motion_enable
-    auto *motion_enable = app.add_subcommand("motion_enable", "send a motion_enable command");
+    auto *motion_enable =
+        app.add_subcommand("motion_enable", "send a motion_enable command");
 
     bool enable_flag{true};
-    motion_enable->add_flag("-e, --enable, -d{false}, --disable{false}", enable_flag, "enable or disable the xArm (default: --enable)");
+    motion_enable->add_flag("-e, --enable, -d{false}, --disable{false}",
+                            enable_flag,
+                            "enable or disable the xArm (default: --enable)");
 
     int servo_option{kAllServo};
-    motion_enable->add_option("-s, --servo", servo_option, "choose servo [1-8] to be enabled/disabled, (default: 8 - enable/disable all servo)");
+    motion_enable->add_option("-s, --servo", servo_option,
+                              "choose servo [1-8] to be enabled/disabled, "
+                              "(default: 8 - enable/disable all servo)");
 
     motion_enable->callback([&]() {
         auto *arm = new XArmAPI(port);
         res = arm->motion_enable(enable_flag, servo_option);
 
-        if (print_mode)
-        {
-            std::cout << "Motion " << (enable_flag ? "enable" : "disable") << " - Response: " << res << "\n";
+        if (print_mode) {
+            std::cout << "Motion " << (enable_flag ? "enable" : "disable")
+                      << " - Response: " << res << "\n";
         }
     });
 
     // Subcommand: set_state
-    auto *set_state = app.add_subcommand("set_state", "send a set_state command");
+    auto *set_state =
+        app.add_subcommand("set_state", "send a set_state command");
 
     int state_option{0};
-    set_state->add_option("-s, --state", state_option, "state, 0: sport, 3: pause, 4: stop");
+    set_state->add_option("-s, --state", state_option,
+                          "state, 0: sport, 3: pause, 4: stop");
 
     set_state->callback([&]() {
         auto *arm = new XArmAPI(port);
         res = arm->set_state(state_option);
 
-        if (print_mode)
-        {
-            std::cout << "Set state: " << state_option << " - Response: " << res << "\n";
+        if (print_mode) {
+            std::cout << "Set state: " << state_option << " - Response: " << res
+                      << "\n";
         }
     });
 
@@ -73,26 +84,32 @@ int main(int argc, char **argv)
     auto *set_mode = app.add_subcommand("set_mode", "send a set_mode command");
 
     int mode_option = 0;
-    set_mode->add_option("-m", mode_option, "mode, 0: position control mode, 1: servo motion mode, 2: joint teaching mode, 3: cartesian teaching mode (invalid), 4: simulation mode");
+    set_mode->add_option(
+        "-m", mode_option,
+        "mode, 0: position control mode, 1: servo motion mode, 2: joint "
+        "teaching "
+        "mode, 3: cartesian teaching mode (invalid), 4: simulation mode");
 
     set_mode->callback([&]() {
         auto *arm = new XArmAPI(port);
         res = arm->set_mode(mode_option);
 
-        if (print_mode)
-        {
-            std::cout << "Set mode: " << mode_option << " - Response: " << res << "\n";
+        if (print_mode) {
+            std::cout << "Set mode: " << mode_option << " - Response: " << res
+                      << "\n";
         }
     });
 
     // Subcommand: get_version
-    auto *get_version = app.add_subcommand("get_version", "send a get_version command");
+    auto *get_version =
+        app.add_subcommand("get_version", "send a get_version command");
     get_version->callback([&]() {
         auto *arm = new XArmAPI(port);
-        res = arm->get_version(arm->version); // TODO(jo-bru): check if this is even needed or arm->version holds an updated version
+        res = arm->get_version(arm->version);  // TODO(jo-bru): check if this is
+                                               // even needed or arm->version
+                                               // holds an updated version
 
-        if (print_mode)
-        {
+        if (print_mode) {
             std::cout << "Get version - Response: " << res << "\n"
                       << "Version: ";
         }
@@ -100,13 +117,13 @@ int main(int argc, char **argv)
     });
 
     // Subcommand: get_state
-    auto *get_state = app.add_subcommand("get_state", "send a get_state commmand");
+    auto *get_state =
+        app.add_subcommand("get_state", "send a get_state commmand");
     get_state->callback([&]() {
         auto *arm = new XArmAPI(port);
         res = arm->get_state(&arm->state);
 
-        if (print_mode)
-        {
+        if (print_mode) {
             std::cout << "Get state - Response: " << res << "\n"
                       << "State: ";
         }
@@ -114,26 +131,28 @@ int main(int argc, char **argv)
     });
 
     // Subcommand: get_position
-    auto *get_position = app.add_subcommand("get_position", "send a get_position command to get the cartesian position");
+    auto *get_position = app.add_subcommand(
+        "get_position",
+        "send a get_position command to get the cartesian position");
     get_position->callback([&]() {
         auto *arm = new XArmAPI(port);
         res = arm->get_position(arm->position);
 
-        if (print_mode)
-        {
+        if (print_mode) {
             std::cout << "Get position - Response: " << res << "\n"
                       << "Position: ";
         }
         std::cout << "[ ";
-        for (int i = 0; i < 6; i++)
-        {
+        for (int i = 0; i < 6; i++) {
             std::cout << arm->position[i] << " ";
         }
         std::cout << "]";
     });
 
     // Subcommand: set_position
-    auto *set_position = app.add_subcommand("set_position", "send a set_position command to get the cartesian position");
+    auto *set_position = app.add_subcommand(
+        "set_position",
+        "send a set_position command to get the cartesian position");
 
     float x_option = kDefaultPosX;
     set_position->add_option("-x", x_option, "x(mm)");
@@ -149,7 +168,8 @@ int main(int argc, char **argv)
     set_position->add_option("-w, --yaw", yaw_option, "yaw(rad or °)");
 
     bool wait_option = false;
-    set_position->add_option("--wait", wait_option, "whether to wait for the arm to complete");
+    set_position->add_option("--wait", wait_option,
+                             "whether to wait for the arm to complete");
 
     set_position->callback([&]() {
         auto *arm = new XArmAPI(port);
@@ -164,14 +184,12 @@ int main(int argc, char **argv)
 
         res = arm->set_position(pose, wait_option);
 
-        if (print_mode)
-        {
+        if (print_mode) {
             std::cout << "Set position - Response: " << res << "\n"
                       << "Position: ";
             std::cout << "[ ";
             // range-based for loop
-            for (float position : pose)
-            {
+            for (float position : pose) {
                 std::cout << position << " ";
             }
             std::cout << "]"


### PR DESCRIPTION
Refactored code using the clang-tidy linter.

The following warnings were resolved:
* llvm-include-order
* google-readability-todo
* readability-magic-numbers
* cppcoreguidelines-owning-memory (`arm = new XArmAPI(port);`)
* readability-qualified-auto
* modernize-loop-convert

The following problems are not yet resolved:
* _do not implicitly decay an array into a pointer; consider using gsl::array_view or an explicit cast insteadclang-tidy(cppcoreguidelines-pro-bounds-array-to-pointer-decay)_ **=>depending on SDK functions, therefore not resolvable (I guess)**
* _an exception may be thrown in function 'main' which should not throw exceptionsclang-tidy(bugprone-exception-escape)_
**=> see issue #10**

I'm not sure if the magic number resolution is correct: not sure if `constexpr` is the right way and where to define them (use namespace or separate header, I suppose not as global constants..)
