### PR TITLE
chore: rename build to bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX = g++
 
-BUILD_DIR = ./build/
+BUILD_DIR = ./bin/
 INC_LIB = ./libs/
 SRC_DIR = ./src/
 XARM_SDK_LIB_DIR = ./libs/xArm-CPLUS-SDK/build/lib/


### PR DESCRIPTION
Another super picky change: when I build something with `make`, I always look for `./bin` instead of `./build`.